### PR TITLE
fix resize2fs giving error

### DIFF
--- a/ubports.sh
+++ b/ubports.sh
@@ -32,6 +32,7 @@ umount /r;
 mv /data/system.img /data/android-rootfs.img
 
 ui_print "Resizing rootfs to 8GB";
+e2fsck -f /data/rootfs.img
 resize2fs /data/rootfs.img 8G
 
 ## end install


### PR DESCRIPTION
Please run 'e2fsck -f /data/rootfs.img' first.